### PR TITLE
[Feat]-Popup Modal 배경 관련 기능 추가

### DIFF
--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -200,7 +200,7 @@ const Modal = ({ show, width, closed }) => {
 	}, [show, scrollPosition]);
 
 	const handleOverlayClick = (e) => {
-		// 클릭한 영역이 ModalWrapper이 아닌 경우 모달을 닫습니다.
+		// 클릭한 영역이 ModalWrapper이 아닌 경우 모달을 닫음
 		if (e.target === e.currentTarget) {
 			closed();
 		}

--- a/src/components/Modal/Modal.jsx
+++ b/src/components/Modal/Modal.jsx
@@ -87,22 +87,22 @@ import React, { useState, useEffect } from 'react';
 import { CSSTransition } from 'react-transition-group';
 // import { Scrollbars } from 'react-custom-scrollbars';
 import {
+	Overlay,
 	ModalWrapper,
 	Title,
 	Subtitle,
 	ModalContent,
-	Table,
 	ButtonContainer,
 	Button,
 	Subject,
 	SubjectContainer
-} from './ModalStyles'; // 경로는 실제 파일 위치에 맞게 조정
+} from './ModalStyles';
 import TableComponent from '../TableComponent';
 
-const animationTiming = {
-	enter: 1000,
-	exit: 1000
-};
+// const animationTiming = {
+// 	enter: 1000,
+// 	exit: 1000
+// };
 
 const Modal = ({ show, width, closed }) => {
 	const [title, setTitle] = useState('');
@@ -114,6 +114,7 @@ const Modal = ({ show, width, closed }) => {
 	const [subtitle3, setSubtitle3] = useState('');
 	const [tableHeaders, setTableHeaders] = useState([]);
 	const [tableRows, setTableRows] = useState([]);
+	const [scrollPosition, setScrollPosition] = useState(0);
 	// const [additionalInfo, setAdditionalInfo] = useState({
 	// 	university: '',
 	// 	department: '',
@@ -185,10 +186,30 @@ const Modal = ({ show, width, closed }) => {
 		// setAdditionalInfo(modalContent.sections[3].text);
 	}, []);
 
+	useEffect(() => {
+		if (show) {
+			// 저장 현재 스크롤 위치
+			setScrollPosition(window.scrollY);
+			// 모달 열 때 스크롤 비활성화
+			document.body.style.overflow = 'hidden';
+		} else {
+			// 모달 닫을 때 원래 위치로 스크롤 복원
+			document.body.style.overflow = 'auto';
+			window.scrollTo(0, scrollPosition);
+		}
+	}, [show, scrollPosition]);
+
+	const handleOverlayClick = (e) => {
+		// 클릭한 영역이 ModalWrapper이 아닌 경우 모달을 닫습니다.
+		if (e.target === e.currentTarget) {
+			closed();
+		}
+	};
+
 	return (
 		<CSSTransition
 			in={show}
-			timeout={animationTiming}
+			//timeout={animationTiming}
 			mountOnEnter
 			unmountOnExit
 			classNames={{
@@ -197,68 +218,56 @@ const Modal = ({ show, width, closed }) => {
 				exit: 'BounceDismiss'
 			}}
 		>
-			<ModalWrapper width={width}>
-				<div>
-					<Title>{title}</Title>
-					<SubjectContainer>
-						<Subject>{subject}</Subject>
-					</SubjectContainer>
+			<Overlay onClick={handleOverlayClick}>
+				<ModalWrapper width={width} onClick={(e) => e.stopPropagation()}>
 					<div>
-						<Subtitle>{subtitle1}</Subtitle>
-						<ModalContent>{text1}</ModalContent>
-					</div>
-					<div>
-						<Subtitle>{subtitle2}</Subtitle>
-						<ModalContent>{text2}</ModalContent>
-					</div>
-					<div>
-						<Subtitle>{subtitle3}</Subtitle>
-						<ModalContent>
-							<Table>
-								<thead>
-									<tr>
-										{tableHeaders.map((header, i) => (
-											<th key={i}>{header}</th>
-										))}
-									</tr>
-								</thead>
-								<tbody>
-									{tableRows.map((row, i) => (
-										<tr key={i}>
-											{row.map((cell, j) => (
-												<td key={j}>{cell}</td>
+						<Title>{title}</Title>
+						<SubjectContainer>
+							<Subject>{subject}</Subject>
+						</SubjectContainer>
+						<div>
+							<Subtitle>{subtitle1}</Subtitle>
+							<ModalContent>{text1}</ModalContent>
+						</div>
+						<div>
+							<Subtitle>{subtitle2}</Subtitle>
+							<ModalContent>{text2}</ModalContent>
+						</div>
+						<div>
+							<Subtitle>{subtitle3}</Subtitle>
+							<ModalContent>
+								<TableComponent>
+									<thead>
+										<tr>
+											{tableHeaders.map((header, i) => (
+												<th key={i}>{header}</th>
 											))}
 										</tr>
-									))}
-								</tbody>
-							</Table>
-						</ModalContent>
+									</thead>
+									<tbody>
+										{tableRows.map((row, i) => (
+											<tr key={i}>
+												{row.map((cell, j) => (
+													<td key={j}>{cell}</td>
+												))}
+											</tr>
+										))}
+									</tbody>
+								</TableComponent>
+							</ModalContent>
+						</div>
+						<div>
+							<Subtitle>Additional information </Subtitle>
+							<ModalContent>
+								<TableComponent />
+							</ModalContent>
+						</div>
+						<ButtonContainer>
+							<Button onClick={closed}>Close</Button>
+						</ButtonContainer>
 					</div>
-					<div>
-						<Subtitle>Additional information </Subtitle>
-						<ModalContent>
-							{/* <p>{additionalInfo.university}</p>
-							<p>{additionalInfo.department}</p>
-							<p>{additionalInfo.lectureType}</p>
-							<p>{additionalInfo.grade}</p>
-							<p>{additionalInfo.semester}</p>
-							<p>{additionalInfo.credits}</p>
-							<p>{additionalInfo.certificationCompletion}</p>
-							<p>{additionalInfo.certificationType}</p>
-							<p>{additionalInfo.certificationDetail}</p>
-							<p>{additionalInfo.sameCourseCode}</p>
-							<p>{additionalInfo.prerequisite}</p>
-							<p>{additionalInfo.mooc}</p>
-							<p>{additionalInfo.selc}</p>
-							<p>{additionalInfo.challenger}</p> */}
-							<TableComponent />
-						</ModalContent>
-					</div>
-					<ButtonContainer>
-						<Button onClick={closed}>Close</Button>
-					</ButtonContainer>
-				</div>
-			</ModalWrapper>
+				</ModalWrapper>
+			</Overlay>
 		</CSSTransition>
 	);
 };

--- a/src/components/Modal/ModalStyles.jsx
+++ b/src/components/Modal/ModalStyles.jsx
@@ -1,6 +1,19 @@
 import styled from 'styled-components';
 import { immergeBounce, dismissBounce } from '../../Animation/Animation';
 
+export const Overlay = styled.div`
+	position: fixed;
+	top: 0;
+	left: 0;
+	right: 0;
+	bottom: 0;
+	background: rgba(0, 0, 0, 0.5); /* 반투명 배경 */
+	display: flex;
+	align-items: center;
+	justify-content: center;
+	z-index: 1000;
+`;
+
 export const ModalWrapper = styled.div`
 	position: fixed;
 	z-index: 200;
@@ -18,6 +31,7 @@ export const ModalWrapper = styled.div`
 	transform: translate(-50%, -50%); /* 모달을 중앙에 배치 */
 	border-radius: 1rem; /* 모서리 둥글게 */
 	box-shadow: 0 4px 8px rgba(0, 0, 0, 0.1); /* 시각적으로 모달을 돋보이게 하는 그림자 추가 */
+	z-index: 1001; /* Overlay보다 위에 표시되도록 설정 */
 
 	&.BounceImmerge {
 		animation: ${immergeBounce} 400ms ease-out forwards;


### PR DESCRIPTION
## 구현 사항
<img width="1490" alt="image" src="https://github.com/user-attachments/assets/688c6ed6-6c24-464b-ba2b-9722dc69699a">


## 구현 설명
- 배경 스크롤 비활성화
- 배경 블러 처리
- 모달 외부 클릭 시 닫기

## 연관된 이슈
close #19 

## 문제점
- 애니메이션 일단 제거 (필요성 논의 후 필요하면 다시 삽입하도록 하겠습니다)
## 향후 개발되어야하는 부분
- 현재 배경 페이지가 밑으로 내려간 상태에서 popup을 띄워도 배경페이지가 제일 위로 올라간다는 문제점 있음
- 하지만 이는 현재 모달을 페이지 내부에서 사용하는 방식이 아닌 모달 페이지로 넘어가는(페이지간 이동)을 하고 있는 중이라 발생하는 문제로 예상됨 -> 사용하고자 하는 페이지 내부에서 불러오는 형식이라면 문제 없을 것 같음